### PR TITLE
  Add option of passing of content type swagger definition as a parameter to getResponseObject so that it can be used outside th plugin to format a cotent type in JSON.

### DIFF
--- a/packages/api/base.cfc
+++ b/packages/api/base.cfc
@@ -68,7 +68,7 @@ component {
 		application.fc.lib.api.clearResponse(res=request.res, res=request.res, argumentCollection=arguments);
 	}
 
-	public struct function getResponseObject(struct stObject, string typename, uuid objectid) {
+	public struct function getResponseObject(struct stObject, string typename, uuid objectid, struct swaggerDef) {
 		var o = {};
 		var stObject = {};
 		var swaggerDef = {};
@@ -76,6 +76,7 @@ component {
 		var stResult = {};
 		var typename = structKeyExists(arguments, "stObject") ? arguments.stObject.typename : arguments.typename;
 		var stItem = {};
+		var oSwagger={};
 
 		if (not structKeyExists(arguments, "stObject")) {
 			o = application.fapi.getContentType(typename=arguments.typename);
@@ -94,7 +95,13 @@ component {
 		}
 
 		// otherwise, use the swagger definition to clean up the response
-		swaggerDef = application.fc.lib.api.swagger[request.req.handler.api].definitions[arguments.stObject.typename].properties;
+		if (structKeyExists(arguments,"swaggerDef")) {					
+			swaggerDef = arguments.swaggerDef
+		}
+		else {
+			swaggerDef = application.fc.lib.api.swagger[request.req.handler.api].definitions[arguments.stObject.typename].properties;
+		}
+		
 		stResult = {
 			"objectid" = arguments.stObject.objectid,
 			"typename" = arguments.stObject.typename

--- a/packages/api/base.cfc
+++ b/packages/api/base.cfc
@@ -68,7 +68,7 @@ component {
 		application.fc.lib.api.clearResponse(res=request.res, res=request.res, argumentCollection=arguments);
 	}
 
-	public struct function getResponseObject(struct stObject, string typename, uuid objectid, struct swaggerDef) {
+	public struct function getResponseObject(struct stObject, string typename, uuid objectid, string api=request.req.handler.api,struct swaggerDef) {
 		var o = {};
 		var stObject = {};
 		var swaggerDef = {};
@@ -94,14 +94,15 @@ component {
 			arguments.stObject = o.getData(typename=arguments.typename, objectid=arguments.objectid, bArraysAsStructs=true);
 		}
 
-		// otherwise, use the swagger definition to clean up the response
-		if (structKeyExists(arguments,"swaggerDef")) {					
-			swaggerDef = arguments.swaggerDef
+		if (structKeyExists(arguments,"swaggerDef")) {
+			// Used passed in definition
+			swaggerDef = arguments.swaggerDef;
 		}
-		else {
-			swaggerDef = application.fc.lib.api.swagger[request.req.handler.api].definitions[arguments.stObject.typename].properties;
+		else {	
+			// otherwise, use the swagger definition to clean up the response
+			swaggerDef = application.fc.lib.api.swagger[arguments.api].definitions[arguments.stObject.typename].properties;			
 		}
-		
+
 		stResult = {
 			"objectid" = arguments.stObject.objectid,
 			"typename" = arguments.stObject.typename


### PR DESCRIPTION
Wanted to use the getResponse function on its own outside the API but it is expecting this structure to already exist 'application.fc.lib.api.swagger'. So have added an optional parameter to pass in a swagger definition to be used instead of lookng for it in the above structure. 